### PR TITLE
ci(security): add CodeQL and Semgrep code scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,48 @@
+# CodeQL static analysis (GitHub-native SAST, free for public repos).
+#
+# Runs on pushes and PRs to main plus a weekly schedule. JavaScript/TypeScript
+# uses `build-mode: none` (no compiled build step needed for this Next.js app).
+# Results upload to the repo Security tab as SARIF.
+#
+# Docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning
+
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "javascript-typescript" ]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,48 @@
+# Semgrep static analysis (free for open source, no token needed).
+#
+# Second SAST opinion alongside CodeQL, focused on OWASP Top 10, security-audit
+# rules, and secrets. Runs the `auto` ruleset in the official container and
+# uploads SARIF to the same Security tab as CodeQL, so both scanners are
+# triaged in one place.
+#
+# Docs: https://semgrep.dev/docs/deployment/add-to-ci/
+
+name: "Semgrep"
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: semgrep/semgrep:latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Semgrep scan
+        # `auto` = community rules matched to this repo's languages.
+        # Exit code is forced to 0 so the SARIF upload always runs;
+        # findings are triaged in the Security tab, not as a red X.
+        run: semgrep scan --config auto --sarif --output semgrep.sarif --error || true
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: semgrep.sarif
+          category: "semgrep"

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ yarn-error.log*
 next-env.d.ts
 
 ### Github ###
-/.github/
+# (workflows live in .github/workflows and MUST be committed)
 
 ### App Scripts ###
 /.google-apps-script/docs


### PR DESCRIPTION
Adds CodeQL (GitHub-native SAST) + Semgrep (second opinion, OWASP/secrets) with SARIF upload to the Security tab. Runs on push/PR to main + weekly. Also un-ignores .github/ so workflows are tracked. Scans run on this PR — results will be triaged here before merge.