### PR TITLE
docs(security): refresh controls docs and add full-project audit plan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,35 +1,42 @@
 # Environment Variables for redwan.work
+#
+# Copy to `.env.local` and fill in. `.env.local` is gitignored — never commit it.
+# Variables prefixed NEXT_PUBLIC_ are inlined at BUILD time: Vercel must hold
+# the production values, otherwise local/dev values ship to production.
 
 # ==============================================
-# Cloudflare Turnstile (Bot Protection)
+# Cloudflare Turnstile (Bot Protection) — required for contact + uploads
 # ==============================================
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
 # ==============================================
-# Site
+# Site — required
 # ==============================================
-# Public origin, used for canonical URLs / auth redirects
+# Public origin, used for canonical URLs, auth redirects, and email links.
+# MUST be https://redwan.work in Vercel production (NOT localhost):
+# lifecycle-email links are built from this value.
 # Example: https://redwan.work or http://localhost:3000
 NEXT_PUBLIC_SITE_URL=
 
 
 # ==============================================
-# Supabase (auth + Postgres)
+# Supabase (auth + Postgres) — required
 # ==============================================
+# New-format keys only: sb_publishable_… / sb_secret_… (legacy anon JWTs forbidden)
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SECRET_KEY=
 
 # ==============================================
-# Leads pipeline (/api/contact)
+# Leads pipeline (/api/contact) — required
 # ==============================================
 # Salt used to hash submitter IPs before storage (never store raw IPs).
 # Generate with: openssl rand -hex 32
 LEAD_IP_HASH_SALT=
 
 # ==============================================
-# Cloudflare R2 (object storage)
+# Cloudflare R2 (object storage) — required
 # ==============================================
 R2_ENDPOINT=
 R2_PUBLIC_BUCKET=
@@ -46,7 +53,7 @@ NEXT_PUBLIC_R2_PUBLIC_BASE_URL=
 CRON_SECRET=
 
 # ==============================================
-# Resend (transactional email)
+# Resend (transactional email) — required for lifecycle emails
 # ==============================================
 # API key from resend.com/api-keys (server-only)
 RESEND_API_KEY=
@@ -56,11 +63,13 @@ RESEND_FROM_EMAIL=
 
 
 # ==============================================
-# Google Blogger API
+# Google Blogger API — required for /blogs (graceful empty state without it)
 # ==============================================
 # Base64-encoded Google service account credentials JSON
 GOOGLE_CREDENTIALS_B64=
 BLOGGER_BLOG_ID=
+# Legacy alias, still honored by lib/blogger.ts — prefer BLOGGER_BLOG_ID
+# BLOGGER_ID=
 
 # Shared secret for POST /api/revalidate (sent as Authorization: Bearer ...)
 REVALIDATION_SECRET=

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Live at [redwan.work](https://redwan.work).
 - **Projects & Files** – deliverables with R2 presigned uploads, archive/purge cycle.
 - **Lifecycle Emails** – 7 transactional events via Resend, audited in `email_log` with an admin viewer.
 - **Security Hardening** – RLS, service‑role RPCs, signed upload sizes, deactivation revocation, generic errors.
+- **Repository Security** – CodeQL + Semgrep on every push/PR, secret scanning with push protection, Dependabot, protected `main`, [`SECURITY.md`](./SECURITY.md) disclosure policy.
 
 Full documentation in [`/docs`](./docs).
 
@@ -115,7 +116,8 @@ Detailed docs for each feature live in `/docs`:
 - [`docs/auth`](./docs/auth) – authentication, sessions, proxy
 - [`docs/crm`](./docs/crm) – admin/client actions, tickets, invoices, projects
 - [`docs/r2`](./docs/r2) – object storage, presigned URLs, retention
-- [`docs/security`](./docs/security) – hardening, probe matrix, residual risks
+- [`docs/security`](./docs/security) – hardening, probe matrix, repo security controls, residual risks
+  - [`docs/security/AUDIT-PLAN.md`](./docs/security/AUDIT-PLAN.md) – full-project audit runbook for a fresh session or agent
 - [`docs/email`](./docs/email) – lifecycle emails, delivery classification, email log
 - [`docs/contact`](./docs/contact) – form, Turnstile, leads
 - [`docs/blogs`](./docs/blogs) – Blogger integration

--- a/README.md
+++ b/README.md
@@ -47,10 +47,16 @@ Full documentation in [`/docs`](./docs).
 
 ### Environment Variables
 
-Create `.env.local` from `.env.example` and fill in:
+Create `.env.local` from `.env.example` and fill in. `.env.local` is
+gitignored — never commit it. Variables prefixed `NEXT_PUBLIC_` are inlined
+at **build** time, so Vercel must hold the production values.
 
 ```env
-# Supabase
+# Site (NEXT_PUBLIC_SITE_URL MUST be https://redwan.work in production —
+# lifecycle-email links are built from it)
+NEXT_PUBLIC_SITE_URL=
+
+# Supabase (new-format keys only: sb_publishable_… / sb_secret_…)
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
 SUPABASE_SECRET_KEY=
@@ -65,21 +71,22 @@ R2_PRIVATE_ACCESS_KEY_ID=
 R2_PRIVATE_SECRET_ACCESS_KEY=
 NEXT_PUBLIC_R2_PUBLIC_BASE_URL=
 
-# Resend
+# Resend (lifecycle emails)
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
 
-# Turnstile
+# Turnstile (bot protection)
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
-# Blogger
+# Blogger (graceful empty state without it)
 BLOGGER_BLOG_ID=
 GOOGLE_CREDENTIALS_B64= # base64 service account JSON
 
 # Misc
-LEAD_IP_HASH_SALT=
-CRON_SECRET=
+LEAD_IP_HASH_SALT=      # openssl rand -hex 32; never store raw IPs
+CRON_SECRET=            # bearer for /api/cron/r2-retention
+REVALIDATION_SECRET=    # bearer for POST /api/revalidate
 ```
 
 ### Install & Run

--- a/docs/security/AUDIT-PLAN.md
+++ b/docs/security/AUDIT-PLAN.md
@@ -1,0 +1,145 @@
+# Full-Project Audit Plan
+
+A repeatable runbook for auditing **redwan.work** end to end — written so a
+fresh session or a different coding agent can execute it with zero prior
+context. Run it before a major release, quarterly, after any dependency bump,
+or whenever the Security tab shows new findings.
+
+**Repo:** `redwan-cse/redwan.work` (public) · **Live:** https://redwan.work
+**Stack:** Next.js 16 App Router + React 19 + TypeScript strict · Tailwind 3 +
+shadcn/ui · Supabase Postgres + Auth (`sb_publishable_` / `sb_secret_` keys
+only) · Cloudflare R2 (public + private buckets) · Resend · Vercel
+(auto-deploys from `main`) · Cloudflare Turnstile.
+
+**How to use this document:** work areas in order (each builds on the trust
+established by the previous one). Every area lists *files to read*, *commands
+to run with expected results*, and *probes* where live verification is needed.
+Record each result as ✅ / ❌ with evidence (command output, row counts,
+HTTP codes). File findings per the rubric in §8.
+
+**Standing rules for every probe run:**
+- Never print secret *values* — env var *names* and presence only.
+- No persistent fixtures: every temporary user, project, ticket, invoice,
+  file, R2 object, and `email_log` row is deleted after probing, with a
+  zero-count confirmation query at the end.
+- Use synthetic addresses only (`…@example.test`); Resend's test mode rejects
+  `example.com`, so use the verified sender as the sink for live-send probes.
+- Redact PII from all notes (mask emails to `abc***@…`, truncate UUIDs).
+
+## 0. Prerequisites
+
+- [ ] Node 20+, `npm`, `gh` CLI (authenticated as repo owner), Supabase CLI linked to project `cqxtmzzlywolulechcob`.
+- [ ] `.env.local` present with (names only — never paste values):
+  `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`,
+  `SUPABASE_SECRET_KEY`, `R2_ENDPOINT`, `R2_PUBLIC_BUCKET`,
+  `R2_PUBLIC_ACCESS_KEY_ID`, `R2_PUBLIC_SECRET_ACCESS_KEY`,
+  `R2_PRIVATE_BUCKET`, `R2_PRIVATE_ACCESS_KEY_ID`,
+  `R2_PRIVATE_SECRET_ACCESS_KEY`, `NEXT_PUBLIC_R2_PUBLIC_BASE_URL`,
+  `RESEND_API_KEY`, `RESEND_FROM_EMAIL`, `NEXT_PUBLIC_TURNSTILE_SITE_KEY`,
+  `TURNSTILE_SECRET_KEY`, `LEAD_IP_HASH_SALT`, `CRON_SECRET`,
+  `BLOGGER_BLOG_ID`, `GOOGLE_CREDENTIALS_B64`, `NEXT_PUBLIC_SITE_URL`.
+- [ ] Baseline gates green on a clean tree:
+  `npm run lint && npx tsc --noEmit && npm run build`
+- [ ] Production reachable: `curl -s -o /dev/null -w "%{http_code}\n" https://redwan.work/` → `200`.
+
+## 1. Repository & supply chain
+
+**Files:** `.github/workflows/*.yml`, `package.json`, `package-lock.json`,
+`.gitignore`, `SECURITY.md`, `next.config.js` (headers section).
+
+- [ ] 1.1 `gh api repos/redwan-cse/redwan.work/code-scanning/alerts?state=open` → expect `[]`. Any open alert is a finding (see §8 for triage).
+- [ ] 1.2 Same for `secret-scanning/alerts?state=open` → expect `[]`.
+- [ ] 1.3 `gh api repos/redwan-cse/redwan.work/dependabot/alerts?state=open` → expect `[]`. If non-empty: note severity/package/count; do not fix inside the audit — file findings and plan a dedicated deps PR.
+- [ ] 1.4 `npm audit --audit-level=low` → expect `found 0 vulnerabilities`. A mismatch with 1.3 (counts differ — Dependabot tracks per-path advisories) is normal; record both numbers.
+- [ ] 1.5 All `uses:` refs in `.github/workflows/*.yml` pinned to full 40-char SHAs (Semgrep flags mutable tags). Check: `grep -n "uses:" .github/workflows/*.yml` — every line must end with `@<40-hex> # <tag>`.
+- [ ] 1.6 Branch protection intact: `gh api repos/redwan-cse/redwan.work/branches/main/protection --jq .required_status_checks.contexts` → must include `CodeQL` and `Scan`; `allow_force_pushes`/`allow_deletions` false.
+- [ ] 1.7 `git ls-files | grep -E '\.env\.local$|pem$|key\.json$'` → expect empty (no secrets tracked). `.env.example` must contain only empty keys.
+- [ ] 1.8 `SECURITY.md` reporting path works: private vulnerability reporting enabled (Settings → Code security), contact address valid.
+
+## 2. Authentication & sessions
+
+**Files:** `proxy.ts`, `lib/auth/actions.ts`, `lib/auth/session.ts`,
+`lib/supabase/server.ts`, `lib/supabase/admin.ts`, `lib/crm/clients.ts`
+(`setClientActive`, `setClaimRole`), `app/login/*`, `app/reset-password/*`,
+`app/invite/accept/*`.
+
+- [ ] 2.1 Unauthenticated `GET /admin`, `/portal`, `/admin/emails`, `/admin/assets` → each `307` to `/login?next=…`. Wrong-role access (client → `/admin/*`, logged-out admin session → admin action) → redirect or `Unauthorized.`
+- [ ] 2.2 Deactivate a temp client via `setClientActive(id, false)`: existing session download of an owned file → generic `404`; sign-in/refresh blocked; reactivate → access restored. Delete fixture.
+- [ ] 2.3 Demote a temp admin to client: an admin-only action with the old session is refused. Delete fixture.
+- [ ] 2.4 OTP throttling: 5 rapid magic-link requests allowed, 6th within 300 s denied with generic `Too many requests…`; `rate_limits` row shows `kind='otp-ip'`. Delete the row.
+- [ ] 2.5 Cookie flags: SSR writes set `httpOnly`, `secure` (production), `sameSite=lax` — check `lib/supabase/server.ts` *and* `proxy.ts` `setAll`.
+- [ ] 2.6 Invite/convert/reset flows complete end to end in staging with a real mailbox; Supabase Auth mail carries the verified domain (DKIM).
+
+## 3. Authorization & database (RLS is the real boundary)
+
+**Files:** `supabase/migrations/0001–0017*.sql` (read-only; migrations are
+forward-only — never edit an applied one), `lib/crm/*.ts`.
+
+- [ ] 3.1 `npx supabase migration list --linked` → `0001`–`0017` local **and** remote, in sync. Any drift is a Critical finding.
+- [ ] 3.2 With a temp **client** JWT + publishable key: `POST /rest/v1/tickets` → denied; `POST /rest/v1/ticket_messages` → denied; `PATCH /rest/v1/invoices {status}` → no-op; `DELETE /rest/v1/payments` → row survives. Delete fixtures.
+- [ ] 3.3 Service-role happy paths still work: draft → `send_invoice_atomic` → `sent`; submit → `confirm_invoice_payment_atomic` → `paid`; `void_invoice_atomic` on `sent`; invoice delete cascades items + payments; direct `status` UPDATE without the `app.invoice_status_transition` marker fails. Delete fixtures.
+- [ ] 3.4 `payment_delete_guard` + `invoice_delete_payment_cascade` triggers exist; `files_attachment_scope_check` allows `ticket_id NULL` only under `/pending/`.
+- [ ] 3.5 Cross-client isolation: client A cannot list, read, or guess IDs for client B's tickets, projects, invoices, or files (expect `[]` / `404`, never a leak). Delete fixtures.
+
+## 4. Storage & uploads (R2)
+
+**Files:** `lib/r2.ts`, `lib/mime.ts`, `lib/crm/files.ts`,
+`app/api/uploads/presign/route.ts`, `app/api/uploads/ticket-presign/route.ts`,
+`app/api/contact/route.ts`, `app/api/cron/r2-retention/route.ts`,
+`app/(admin)/admin/assets/*`.
+
+- [ ] 4.1 Presigned PUT binds `ContentLength`: PUT of exactly the declared size succeeds; ±1 byte is rejected by R2 (signature mismatch).
+- [ ] 4.2 Confirm-time verification: presign 1 KB → PUT 1 KB → confirm declaring 10 MB is rejected by `verifyStoredObjectSize`.
+- [ ] 4.3 Key scoping: `contact/…` key rejected for a deliverable row; deliverable key for project A rejected when confirming for project B; non-`/pending/` ticket-less attachment insert fails the CHECK.
+- [ ] 4.4 Ticket-presign abuse paths: cross-origin POST → `403`; 4th presign in 60 s for one client → `429` with a `presign-portal` row; missing salt / DB outage → denied, never allowed.
+- [ ] 4.5 Asset uploader (admin): valid png ≤5 MB → CDN URL that GETs 200 with identical bytes; 6 MB / `.exe` / mime-mismatch → `400`; delete → origin `NotFound` (note: CDN edge may serve a stale HIT — spec'd cache-forever behavior, not a bug).
+- [ ] 4.6 Retention cron: unauthenticated `GET /api/cron/r2-retention` → `401`; with bearer → `200 {deleted, examined}`; orphan `pending/` objects older than 24 h are removed; contact attachments older than 90 days (unretained) are purged.
+- [ ] 4.7 `connect-src` in the production CSP contains the Supabase origin *and* the R2 origins: `curl -s -D - https://redwan.work/ | grep -i content-security-policy`.
+
+## 5. Lifecycle email
+
+**Files:** `lib/email/*`, `lib/crm/email-log.ts`, `app/(admin)/admin/emails/page.tsx`,
+`supabase/migrations/0016_email_log.sql`.
+
+- [ ] 5.1 All 7 templates render with hostile input (`<img src=x onerror=…>` in every interpolated field) → output contains zero raw markup.
+- [ ] 5.2 Each event produces its row: invite (handoff), new-ticket, reply-posted ×2 directions, status-changed, deliverable-uploaded, invoice-issued, payment-confirmed — correct `template`/`entity_type`/`entity_id`.
+- [ ] 5.3 Fail-soft proof: force a send failure (bad recipient or removed key) → triggering action still returns `ok`, row lands with `status='failed'`.
+- [ ] 5.4 No message content in `email_log`: `select *` over test rows contains no subject/body/filename/amount strings.
+- [ ] 5.5 `/admin/emails` as admin renders the table with working filters/pagination; as client → bounced; logged out → `307` to login.
+- [ ] 5.6 `email_log` row count is sane (no unbounded growth since last audit); decide whether the retention window decided earlier is now due.
+
+## 6. Transport, headers & abuse controls
+
+**Files:** `next.config.js`, `proxy.ts`, `app/api/contact/route.ts`,
+`lib/contact/*`, `app/api/revalidate/route.ts`.
+
+- [ ] 6.1 Production headers on `/`: `Content-Security-Policy` (no hardcoded project ref — derived from env), `Strict-Transport-Security` (includeSubDomains + preload), `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`.
+- [ ] 6.2 Contact abuse paths: cross-origin POST → `403`; Turnstile failure → `400`; token reuse → `400`; IP over budget → `429`; oversized/invalid attachment metadata → generic `Attachment data is invalid…`.
+- [ ] 6.3 Every client-reachable error path returns fixed copy: trigger each former leak (ticket count, file save, reply, presign) and confirm bodies contain no DB/storage/constraint text.
+- [ ] 6.4 Revalidate endpoint: missing/bad bearer → `401`; wrong path → refused.
+
+## 7. Privacy & data lifecycle
+
+- [ ] 7.1 No PII in logs: grep server logs produced during probing for emails, names, payment references, filenames — expect none outside the `email_log.to_email` audit column.
+- [ ] 7.2 Retention operating: R2 orphans purged (§4.6), `email_log` window per §5.6 decision, contact attachments honored per `retained` flags.
+- [ ] 7.3 Backups: `archive/project_<id>/<ISO>.zip` downloads contain `project.json` + `milestones.json` + `files/…` with matching bytes; purge removes rows + objects (verify counts hit 0).
+- [ ] 7.4 Third-party data map still accurate: Supabase (auth + Postgres), R2 (attachments/deliverables/assets), Resend (SMTP + API), Turnstile (bot checks), Blogger (read-only posts). No new vendor since last audit.
+
+## 8. Recording findings
+
+| Severity | Meaning | Examples |
+|---|---|---|
+| Critical | Must not ship / must hotfix: bypasses auth, leaks data across clients, deletes or corrupts data, secrets exposed | RLS bypass, IDOR, session survives deactivation, private key in repo |
+| Important | Should fix before next release: fail-open limiter, error leak, missing audit row, broken probe that hid a regression | fail-open rate limit, DB text in response, unsent event with no log row |
+| Minor | Ship and track: polish, defense-in-depth, docs drift, flaky probe | unbounded fan-out at scale, missing legend, stale comment |
+
+For each finding record: area (§), file:line, observed vs expected (with exact output), severity, and suggested fix. Dismiss a scanner finding **only** with a sink-level justification (where the value is rendered, why it is safe) recorded both in code comment and in the finding — never silently.
+
+## 9. Sign-off
+
+- [ ] All 7 areas executed; every checkbox is ✅ or a filed finding.
+- [ ] Zero open code/secret alerts or all are triaged findings above.
+- [ ] Dependabot at 0 open or new alerts filed as findings.
+- [ ] Fixture sweep: `profiles` holds only real users; all CRM tables and `email_log` back to pre-audit counts; no R2 probe objects remain.
+- [ ] Docs updated for anything the audit changed or discovered (`docs/security/README.md` residual list, `docs/email/README.md` matrix as applicable).
+- [ ] Gates green on the final tree: `npm run lint && npx tsc --noEmit && npm run build`.

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -1,6 +1,9 @@
-# Security Hardening (Phase 5a)
+# Security Hardening & Repository Security
 
-This document summarizes the security hardening applied in Phase 5a (`feat/p5a-security-hardening`) to close four high-severity audit findings and several supporting gaps.
+This document covers the application-layer hardening (Phases 5a/5c), the
+lifecycle-email audit trail (Phase 5b), and the repository-level security
+controls (scanners, secrets, dependencies, branch protection) that guard every
+change going forward.
 
 ## Audit Findings and Fixes
 
@@ -92,20 +95,61 @@ closed on genuine RPC/salt errors. Verified end-to-end: 5 rapid
 `consume_rate_limit('otp-ip', …)` calls allowed, 6th denied — see the Task 5
 report.
 
-## Residual Risks (Deferred beyond P5c)
+## Residual Risks (Tracked, Not Deferred Phases)
 
-The following items were identified but deferred to later phases (lifecycle emails and `email_log` shipped in P5b — see [docs/email/README.md](../email/README.md)):
+All planned phases (P1 → P5c) are shipped. What remains is continuous and
+operational rather than phased work:
 
-- Helper duplication, dead exports, N+1 hydration (P5c)
-- Dependabot vulnerabilities (dedicated PR)
-- Staging browser probes (cross‑client, payment UI, print) – blocked by missing Chromium / malformed MCP; to be run in staging
+- **Staging browser probes** (cross‑client, payment UI, print, `/admin/assets`
+  upload/delete click-through, `/admin/emails` as admin vs client) — blocked
+  historically by missing Chromium; run in staging with a real browser.
+- **`email_log` grows unbounded** — no retention policy yet (unlike R2 objects).
+  Decide a window (e.g. 365 days) and add a cron purge.
+- **No bounce or complaint handling** — Resend webhooks are not wired, so a hard
+  bounce after a `sent` row leaves the log optimistic.
+- **Deactivation does not stop email** — a deactivated client with a pending
+  invoice still receives lifecycle mail.
+- **`HANDOFF_MARKER` string coupling** — editing that sentence reclassifies
+  historical handoff rows; a `delivery_confidence` column would be cleaner.
+- **Preview deployments inherit production `NEXT_PUBLIC_SITE_URL`** — preview
+  emails carry production links. Scope the variable per Vercel environment.
+- **`emailOrigin` has no scheme check beyond `https?`** and `adminRecipients()`
+  fans out serially against Resend's 10 req/s default — fine at current scale.
+- **Dependabot is continuous** — 0 open alerts as of the last sweep; new CVEs
+  arrive weekly via the scheduled scans. Triage new highs within 7 days.
+
+## Repository Security Controls
+
+Every push and pull request to `main` runs both scanners; results land in the
+[Security tab](https://github.com/redwan-cse/redwan.work/security):
+
+| Control | Configuration |
+|---|---|
+| CodeQL SAST | Default setup, `javascript-typescript` + `actions`; runs on push/PR + weekly |
+| Semgrep SAST | `.github/workflows/semgrep.yml` (`auto` ruleset: OWASP, security-audit, secrets); SARIF uploaded to the same tab |
+| Action pinning | All `uses:` refs pinned to full commit SHAs (Semgrep flags mutable tags) |
+| Secret scanning | Enabled, with push protection (secret-bearing pushes are blocked) |
+| Dependabot | Alerts + security updates enabled; swept to 0 open alerts (next 16.3.4, sharp 0.35.4) |
+| Branch protection | `main` requires CodeQL + Semgrep checks (strict), no force-push/deletion, no reviewer requirement (solo project) |
+| Vulnerability reporting | Private reporting enabled; public policy in [`SECURITY.md`](../../SECURITY.md) |
+
+### SAST findings to date (all closed)
+
+| # | Rule | File | Resolution |
+|---|---|---|---|
+| 1 | `js/double-escaping` | `lib/blogger.ts` (`extractExcerpt`) | Fixed — `&amp;` now decodes last, giving true single-pass semantics |
+| 2 | `js/incomplete-multi-character-sanitization` | `lib/blogger.ts` | False positive in context (sole consumer renders JSX text, React-escaped; verified no `dangerouslySetInnerHTML` on the path) — documented in code, dismissed with justification |
+| 3–7 | Unpinned GitHub Actions | `.github/workflows/*.yml` | Fixed — all refs pinned to SHAs |
+| 8 | `unsafe-formatstring` (note) | `lib/email/index.ts` | Fixed — constant format string |
+
+Alerts auto-resolve when the fix lands on `main`; false-positive dismissals are re-evaluated per analysis and re-dismissed with the same recorded justification if a finding reappears on moved lines.
 
 ## Operator Notes
 
 - **Deactivation now revokes sessions**: when `setClientActive(clientId, false)` is called, the auth admin sign‑out API is invoked. The caller receives an error if revocation fails, preventing a scenario where a deactivated user might hold a live session.
 - **Service‑role RPCs are the only write path** for tickets, invoices, items, payments, and file status. Any direct REST mutation will be rejected by RLS or guard triggers.
 - **Client‑facing errors are generic** – if you need to debug, inspect the server logs (console.error) which contain the original error details.
-- **Migration ordering**: `0014_security_hardening.sql` applies the core hardening; `0015_presign_portal_rate_kind.sql` adds the new rate‑limit kind for ticket‑presign; `0017_otp_rate_kind.sql` adds `'otp-ip'` for OTP throttling. All are forward‑only and already applied in production.
+- **Migration ordering**: `0014_security_hardening.sql` applies the core hardening; `0015_presign_portal_rate_kind.sql` adds the rate‑limit kind for ticket‑presign; `0016_email_log.sql` adds the email audit table; `0017_otp_rate_kind.sql` adds `'otp-ip'` for OTP throttling. All are forward‑only and already applied in production.
 - **Probe environment**: all probes run against the live Supabase project and R2; they create and delete temporary resources. No real customer data is touched.
 
 ## Related Documentation


### PR DESCRIPTION
Updates docs/security/README.md to current state (repo controls table, closed SAST findings, accurate residuals), links the audit plan from README, and adds docs/security/AUDIT-PLAN.md — a repeatable 9-section runbook for auditing the full project from a fresh session. Docs only, no runtime changes.