### PR TITLE
chore(contact): remove retired Google Forms entry.* payload and docs

### DIFF
--- a/components/enhanced-contact-form.tsx
+++ b/components/enhanced-contact-form.tsx
@@ -48,24 +48,16 @@ import { formatBytes } from '@/lib/format';
  * Enhanced Contact Form Component with Cloudflare Turnstile Protection
  * 
  * This component collects rich lead data for cybersecurity services.
- * It submits to an API route (/api/contact) which validates the Turnstile token
- * and then forwards the data to Google Forms.
- * 
- * SETUP INSTRUCTIONS:
- * 1. Create a Google Form with all required fields (19 fields total)
- * 2. Get the form's "formResponse" URL (replace /viewform with /formResponse)
- * 3. Inspect each field to get entry IDs (entry.XXXXXXXXX)
- * 4. Set environment variables:
- *    - NEXT_PUBLIC_TURNSTILE_SITE_KEY: Cloudflare Turnstile site key
- *    - TURNSTILE_SECRET_KEY: Cloudflare Turnstile secret key (server-only)
- *    - GOOGLE_FORM_ACTION_URL: Google Forms submission URL
- * 5. Apps Script in Google Sheets will handle email notifications and data processing
- * 
- * FIELD MAPPING:
- * Each form field maps to a Google Form entry ID.
- * Hidden/derived fields (sourcePage, userAgent, deviceType, priority, status)
- * are automatically collected and sent along with user inputs.
- * Google Forms automatically adds a timestamp as the first column in the linked Sheet.
+ * It submits to an API route (/api/contact) which validates the Turnstile
+ * token and stores the lead in Supabase Postgres (P1 Supabase-only pipeline).
+ *
+ * Required env (client side): NEXT_PUBLIC_TURNSTILE_SITE_KEY.
+ * The server route needs TURNSTILE_SECRET_KEY, Supabase credentials,
+ * and LEAD_IP_HASH_SALT — see .env.example.
+ *
+ * Submitted fields use raw names (name, email, …); the server parser reads
+ * only those. (The retired Google Forms backend used entry.* IDs; they were
+ * removed with the P1 cutover and must not be reintroduced.)
  */
 
 /**
@@ -875,32 +867,8 @@ export default function EnhancedContactForm() {
        * NOTE: timestamp is NOT included - Google Forms adds its own timestamp automatically
        */
       const formFields = new FormData();
-      
-      // Add all form fields
-      formFields.append('entry.1040615996', submissionData.name);
-      formFields.append('entry.527020986', submissionData.email);
-      formFields.append('entry.275586996', submissionData.country);
-      formFields.append('entry.691109542', submissionData.whatsAppNumber);
-      formFields.append('entry.2004275388', submissionData.preferredContactMethod);
-      formFields.append('entry.876535023', submissionData.timeZone);
-      formFields.append('entry.825634052', submissionData.preferredContactDate);
-      formFields.append('entry.2142614790', submissionData.bestTimeToContact);
-      formFields.append('entry.762760499', submissionData.serviceType);
-      formFields.append('entry.554909735', submissionData.company);
-      formFields.append('entry.688437948', submissionData.projectUrlOrFiles);
-      formFields.append('entry.428546032', submissionData.projectSummary);
-      formFields.append('entry.739578366', submissionData.ndaConfidentiality);
-      formFields.append('entry.663205754', submissionData.urgency);
-      formFields.append('entry.1932264358', submissionData.budgetRange);
-      formFields.append('entry.1784832711', submissionData.howDidYouFindMe);
-      formFields.append('entry.233094040', submissionData.ticketId);
-      formFields.append('entry.209109331', submissionData.sourcePage);
-      formFields.append('entry.1734132568', submissionData.userAgent);
-      formFields.append('entry.1030161553', submissionData.deviceType);
-      formFields.append('entry.279561249', submissionData.priority);
 
-      // Raw-named mirrors for the Supabase sink (Google ignores unknown params,
-      // and our forward paths strip non-entry.* keys anyway)
+      // Raw-named fields for the Supabase sink (the only sink since P1).
       formFields.append('name', submissionData.name);
       formFields.append('email', submissionData.email);
       formFields.append('country', submissionData.country);
@@ -935,7 +903,7 @@ export default function EnhancedContactForm() {
         formFields.append('cf-turnstile-response', submitToken);
       }
 
-      // Submit to our API route (which validates Turnstile and forwards to Google Forms)
+      // Submit to our API route (validates Turnstile, rate-limits, stores the lead)
       const response = await fetch('/api/contact', {
         method: 'POST',
         body: formFields,

--- a/docs/contact/README.md
+++ b/docs/contact/README.md
@@ -98,67 +98,18 @@ If validation fails on submit:
 > • Time Zone
 > • GDPR Consent
 
-## Google Forms Integration
+## Google Forms Integration (RETIRED 2026-08-24)
 
-### How It Works
+The Google Forms + Sheets backend was retired by the P1 Supabase-only cutover
+(see [Phase 1: Supabase Leads Sink](#phase-1-supabase-leads-sink) below).
+`/api/contact` stores every lead in Supabase Postgres only; no `LEADS_SINK`
+flag exists and no Google endpoint is called. The client sends raw-named
+fields only — the old `entry.*` mirrors were removed with the cutover.
 
-1. User fills out form and clicks "Send Message"
-2. Client-side validation runs
-3. If valid, data is formatted and POST to Google Forms
-4. Uses `no-cors` mode (response not readable, but submission works)
-5. Success assumed if no error thrown
-6. Success message shown with Ticket ID
-
-### Field Mapping
-
-Each form field maps to a Google Forms entry ID (e.g., `entry.123456789`).
-
-**Setup Steps:**
-
-1. Create a Google Form with 19 fields matching the form
-2. Get the form action URL:
-   - Open form in edit mode
-   - Replace `/viewform` with `/formResponse` in URL
-3. Inspect form to find entry IDs:
-   - Right-click field → Inspect
-   - Look for `entry.XXXXXXXXX` in HTML
-4. Update mappings in `/components/enhanced-contact-form.tsx`
-5. Set environment variable:
-   ```env
-   NEXT_PUBLIC_GOOGLE_FORM_ACTION_URL=https://docs.google.com/forms/d/e/FORM_ID/formResponse
-   ```
-
-### Google Sheets Integration
-
-Google Forms automatically saves to linked Google Sheets with columns:
-1. Timestamp (auto)
-2. Ticket ID
-3. Full Name
-4. Email
-5. Country
-6. WhatsApp Number
-7. Preferred Contact Method
-8. Time Zone
-9. Preferred Contact Date
-10. Best Time to Contact
-11. Service Type
-12. Company
-13. Budget Range
-14. Project Summary
-15. How Did You Find Me
-16. Urgency
-17. NDA Required
-18. GDPR Consent
-19. Source Page
-20. User Agent
-21. Device Type
-22. Priority
-23. Status
-
-**Optional:** Use Google Apps Script to:
-- Send email notifications on new submission
-- Auto-assign priority/status
-- Trigger webhooks to CRM
+This section is kept as a historical record of the pre-P1 setup (19-field
+form, `entry.*` IDs, linked Sheet, Apps Script notifications). Do not
+reintroduce it: the client-generated ticket ID it relied on was spoofable
+(known S6 issue, now closed by server-issued ticket refs).
 
 ## Extending the Form
 
@@ -275,9 +226,8 @@ Contains:
 ## Troubleshooting
 
 **Form submission doesn't work:**
-- Check `NEXT_PUBLIC_GOOGLE_FORM_ACTION_URL` is set
-- Verify Google Form is set to "Anyone can respond"
-- Check entry IDs match between form and Google Form
+- Check Supabase credentials (`NEXT_PUBLIC_SUPABASE_URL`, `SUPABASE_SECRET_KEY`) and `LEAD_IP_HASH_SALT` are set
+- Check Turnstile keys are valid and the token isn't being reused
 - Open browser console for errors
 
 **Validation not working:**


### PR DESCRIPTION
## Objective completed in integrated PR56, proposed supersession

Owner lifted this PR's deferral September9 at14:47 Asia/Dhaka and included all14 open PRs. Rather than replaying this older branch over current security/consent changes, the cleanup was completed on the integrated candidate.

Replacement code: https://github.com/redwan-cse/redwan.work/commit/5039df98d7ac7354eaa2b87577c7f155583b3a9d . Replacement PR: https://github.com/redwan-cse/redwan.work/pull/56 . All14 disposition: docs/security/ALL-14-PR-DISPOSITION-2026-09-09.md on56.

- [x] Remove21 retired entry.* mirrors, unused budgetRange/ticketId/userAgent payload fields and their dead derived values.
- [x] Remove obsolete Forms/Apps Script/entry-ID comments and rename the obsolete date variable while preserving its format.
- [x] Preserve exactly one actual gdprConsent value, numeric budgetMin/budgetMax, source/device context, consumed lead fields, attachment metadata and fresh Turnstile token.
- [x] Remove fabricated client ticket references; show only a successful server-issued reference. Failed or missing-reference responses retain inputs and never show a fake ID.
- [x] Current docs state Supabase-only intake and required LEAD_IP_HASH_SALT. The old optional-salt review suggestion described an older fail-open server and must NOT weaken the integrated guard.
- [x] Input blob guards and intended legacy regression RED; actual serialization GREEN for every live key/consent/token/attachment metadata. Lint/strict types/build and real Chromium1280/390 consent/failure/retry/missing-reference/success/overflow acceptance ran before the development-only integration commit: https://github.com/redwan-cse/redwan.work/actions/runs/34331279657/job/102400198438 .
- [ ] Final replacement-head repeatable acceptance tracked on56; do not substitute this branch's historical checks for the new candidate.

The three review findings are addressed by replacement implementation/evidence above, not by claiming this old head changed or its threads were manually resolved. This PR remains at9ec956e826dda07ae6852bc00be586f0840d989c until separately confirmed closure. Proposed close reason: superseded by unmerged56, NOT deployed or merged.

No production access/write/retry, real contact submission, email, token operation, migration, R2/Cron operation or main deployment. Browser mocked only the local contact response and blocked external requests. No merge/closure/branch deletion performed. Application release gates remain on56.